### PR TITLE
Add Catch2 contrib dir from SOURCE_DIR

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,11 @@ if (NOT TARGET Catch2)
     GIT_TAG        "v2.13.6"
     GIT_SHALLOW    On)
   FetchContent_MakeAvailable(Catch2)
-  list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+endif()
+
+if (TARGET Catch2)
+  get_target_property(CATCH2_SOURCE_DIR Catch2 SOURCE_DIR)
+  list(APPEND CMAKE_MODULE_PATH "${CATCH2_SOURCE_DIR}/contrib")
 endif()
 
 add_executable(speedyj-test


### PR DESCRIPTION
Fixes a bug if `speedyj` is pulled in before `Catch2` by a parent project.